### PR TITLE
Set AssetsPickerViewController minimum version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
                  <source url="https://github.com/CocoaPods/Specs.git"/>		
              </config>		
              <pods use-frameworks="true">		
-                 <pod name="AssetsPickerViewController" spec="~> 2.0" />		
+                 <pod name="AssetsPickerViewController" spec="~> 2.7.5" />		
              </pods>		
          </podspec>
     </platform>


### PR DESCRIPTION
Our build failed with message:

"Plugins/cordova-plugin-wm-file/WMFilePickerPlugin.swift:175:29: error: value of type 'AssetsPickerConfig' has no member 'assetsMaximumSelectionCount'
        picker.pickerConfig.assetsMaximumSelectionCount = multiple ? Int.max : 1;"

The method assetsMaximumSelectionCount was added in 2.7.5:

https://github.com/DragonCherry/AssetsPickerViewController/compare/2.7.4...2.7.5

We now solved this by Flushing the pod cache on the build-server, but it would be better if correct minimum-version is specified.