### PR TITLE
Android 13 support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,10 +30,15 @@
 
     <!-- android -->
     <platform name="android">
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+        <config-file target="AndroidManifest.xml" parent="/*" mode="merge">
+            <uses-permission android:maxSdkVersion="32" android:name="android.permission.READ_EXTERNAL_STORAGE" />
+            <uses-permission android:maxSdkVersion="32" android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+          
+            <uses-permission android:minSdkVersion="33" android:name="android.permission.READ_MEDIA_AUDIO" />
+            <uses-permission android:minSdkVersion="33" android:name="android.permission.READ_MEDIA_IMAGES" />
+            <uses-permission android:minSdkVersion="33" android:name="android.permission.READ_MEDIA_VIDEO" />
         </config-file>
+      
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FilePicker">
                 <param name="android-package" value="com.wavemaker.cordova.plugin.FilePickerPlugin" />

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -22,6 +22,8 @@ package com.wavemaker.cordova.plugin;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import android.util.Log;
 
@@ -129,10 +131,32 @@ public class FileUtils {
                 }
                 outputStream.flush();
             }
+
+            long originalDate = getFileModifiedDate(context, uri);
+            file.setLastModified(originalDate);
+
             return file;
         } catch (Exception e) {
             Log.e(TAG, "Exception occured", e);
         }
         return  null;
     }
+
+	private static Long getFileModifiedDate(Context context, Uri uri) {
+        Cursor cursor = context.getContentResolver().query(uri, null, null, null, null, null);
+        if (cursor != null && cursor.moveToFirst()) {
+            int columnIndex = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_MODIFIED);
+            if (columnIndex == -1) {
+                columnIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED);
+            }
+            if (columnIndex != -1) {
+                String dateStr = cursor.getString(columnIndex);
+                if (dateStr != null) {
+                    return Long.parseLong(dateStr);
+                }
+            }
+        }
+
+        return null;
+	}
 }


### PR DESCRIPTION
Setup new Android 13 permissions for accessing files media 

[READ_EXTERNAL_STORAGE](https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE)

Note: Starting in API level 33, this permission has no effect. If your app accesses other apps' media files, request one or more of these permissions instead: [READ_MEDIA_IMAGES](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_IMAGES), [READ_MEDIA_VIDEO](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_VIDEO), [READ_MEDIA_AUDIO](https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_AUDIO). Learn more about the [storage permissions](https://developer.android.com/training/data-storage/shared/media#storage-permission) that are associated with media files.